### PR TITLE
Fix: duplicated model definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Run with debug mode (real-time reload changes):
 flask run --debug
 ```
 
+If there are any database migrations, you need to run the following command to upgrade the database:
+
+```bash
+flask db upgrade
+```
+
 ## Running tests
 
 To run the tests, use the following command:

--- a/server/models.py
+++ b/server/models.py
@@ -153,7 +153,7 @@ METRICS_REQUIREMENTS = {
     ExerciseType.RUNNING: ["distance_km", "duration_min"],
     ExerciseType.SWIMMING: ["distance_m", "duration_min"],
     ExerciseType.WEIGHTLIFTING: ["weight_kg", "sets", "reps"],
-    ExerciseType.YOGA: ["duration"],
+    ExerciseType.YOGA: ["duration_min"],
 }
 
 
@@ -210,27 +210,7 @@ BODY_MEASUREMENT_UNITS = {
     BodyMeasurementType.BODY_FAT: ["%"],
 }
 
-class ScheduledExercise(db.Model):
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    exercise_type = db.Column(db.Enum(ExerciseType), nullable=False)
-    scheduled_time = db.Column(db.Time, nullable=False)
-    note = db.Column(db.Text, nullable=True)
-    day_of_week = db.Column(db.String(10), nullable=False)  # e.g. "Monday", "Tuesday", etc.
 
-    user = db.relationship("User", backref="scheduled_exercises")
-    
-class Goal(db.Model):
-    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    description = db.Column(db.String(256), nullable=False)
-    target_value = db.Column(db.Float, nullable=False)
-    current_value = db.Column(db.Float, nullable=False, default=0)
-    unit = db.Column(db.String(32), nullable=True)  # e.g. "kg", "km", "min"
-    created_at = db.Column(db.DateTime, nullable=False, default=db.func.current_timestamp())
-
-    user = db.relationship("User", backref="goals")
-    
 class BodyMeasurement(db.Model):
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)

--- a/tests/test_models/test_exercise.py
+++ b/tests/test_models/test_exercise.py
@@ -6,9 +6,9 @@ class TestExerciseModel:
     @pytest.mark.parametrize(
         "exercise_type,valid_metrics",
         [
-            (ExerciseType.RUNNING, {"distance_km": 5.0, "duration": 30}),
+            (ExerciseType.RUNNING, {"distance_km": 5.0, "duration_min": 30}),
             (ExerciseType.WEIGHTLIFTING, {"weight_kg": 50.0, "sets": 3, "reps": 12}),
-            (ExerciseType.YOGA, {"duration": 45}),
+            (ExerciseType.YOGA, {"duration_min": 45}),
         ],
     )
     def test_valid_exercise_creation(self, session, exercise_type, valid_metrics):
@@ -25,7 +25,7 @@ class TestExerciseModel:
         "exercise_type,invalid_metrics",
         [
             # Single field missing
-            (ExerciseType.RUNNING, {"duration": 30}),
+            (ExerciseType.RUNNING, {"duration_min": 30}),
             (ExerciseType.CYCLING, {"distance_km": 10}),
             (ExerciseType.SWIMMING, {"distance_m": 50}),
             (ExerciseType.WEIGHTLIFTING, {"weight_kg": 50, "sets": 3}),
@@ -56,7 +56,7 @@ class TestExerciseModel:
         exercise = Exercise(
             user_id=1,
             type=ExerciseType.RUNNING,
-            metrics={"distance_km": 5.0, "duration": 30},
+            metrics={"distance_km": 5.0, "duration_min": 30},
         )
         session.add(exercise)
         session.commit()


### PR DESCRIPTION
Change duration to `duration_min` for YOGA types.
Remove duplicated `ScheduledExercise` and `Goal` models from `models.py`.