### PR TITLE
feat: improve badge display logic and formatting in center.html

### DIFF
--- a/server/blueprints/dashboard/templates/dashboard/center.html
+++ b/server/blueprints/dashboard/templates/dashboard/center.html
@@ -36,26 +36,33 @@
                                           style="background: {{ icon_colors[ex_type.value] }};">
                                         {{ icons[ex_type.value] }}
                                     </span>
-                                <strong style="font-size:1.1em;">{{ ex_type }}</strong>:
+                                <strong style="font-size:1.1em;white-space: nowrap;">{{ ex_type }}</strong>:
                                 <span class="ms-2">
-                                        {% for milestone in milestones %}
-                                            {% set idx = loop.index0 %}
-                                            {% set badge_label = badge_labels[idx] %}
-                                            {% if milestone in achievements_by_type[ex_type] %}
-                                                {% set badge_class = badge_classes[idx] %}
-                                            {% else %}
-                                                {% set badge_class = 'badge-locked' %}
-                                            {% endif %}
-                                            <span class="badge {{ badge_class }} me-1" title="{{ badge_label }}">
-                                            {{ badge_label }}
+                                    {% for milestone in milestones %}
+                                        {% set idx = loop.index0 %}
+                                        {% set badge_label = badge_labels[idx] %}
+                                        {% if milestone in achievements_by_type[ex_type] %}
+                                            <span class="badge {{ badge_classes[idx] }} me-1" title="{{ badge_label }}">
+                                                {{ badge_label }}
                                                 {% if units[ex_type.value] == "M" %}
                                                     {{ (milestone/1000)|int }}KM
                                                 {% else %}
                                                     {{ milestone|int }}{{ units[ex_type.value] }}
                                                 {% endif %}
-                                        </span>
-                                        {% endfor %}
-                                    </span>
+                                            </span>
+                                        {% else %}
+                                            <span class="badge badge-locked me-1 position-relative"
+                                                  title="{{ badge_label }}">
+                                                <i class="bi bi-lock-fill"></i>
+                                                {% if units[ex_type.value] == "M" %}
+                                                    {{ (milestone/1000)|int }}KM
+                                                {% else %}
+                                                    {{ milestone|int }}{{ units[ex_type.value] }}
+                                                {% endif %}
+                                            </span>
+                                        {% endif %}
+                                    {% endfor %}
+                                </span>
                             </div>
                         {% endfor %}
                     </div>


### PR DESCRIPTION
This pull request improves the display of achievement badges on the dashboard by refining the layout and adding better support for units and locked milestones.

### Improvements to badge display:
* Updated the `dashboard/center.html` template to ensure the `ex_type` label is displayed without wrapping by adding a `white-space: nowrap;` style.
* Enhanced the badge rendering logic:
  - Replaced conditional setting of `badge_class` with inline rendering of badges, making the code more concise and readable.
  - Added support for displaying milestone units (`KM` or other units) directly within the badge, depending on the type of achievement.
  - Improved the visual representation of locked badges by including a lock icon (`<i class="bi bi-lock-fill"></i>`) and using a `badge-locked` class with a `position-relative` style for better alignment.